### PR TITLE
Fix problem where the Shift state is not cleared after releasing the Shift key

### DIFF
--- a/atari800-MacOSX/src/Atari800MacX/atari_mac_sdl.c
+++ b/atari800-MacOSX/src/Atari800MacX/atari_mac_sdl.c
@@ -2704,7 +2704,8 @@ int Atari_Keyboard_International(void)
         /* Poll for SDL events.  All we want here are Keydown and Keyup events,
          and the quit event. */
         checkForNewJoysticks();
-        if (SDL_PollEvent(&event)) {
+        int pollEvent;
+        if ((pollEvent = SDL_PollEvent(&event))) {
             switch (event.type) {
                 case SDL_TEXTINPUT:
                     kbhits = (Uint8 *) SDL_GetKeyboardState(NULL);
@@ -2759,10 +2760,7 @@ int Atari_Keyboard_International(void)
                     return AKEY_NONE;
             }
         }
-        else {
-            return AKEY_NONE;
-        }
-        
+
         if (kbhits == NULL) {
             Log_print("oops, kbhits is NULL!");
             Log_flushlog();
@@ -2792,6 +2790,10 @@ int Atari_Keyboard_International(void)
                 copyStatus = COPY_IDLE;
             else if (lastkey != SDL_SCANCODE_LGUI && lastkey != SDLK_c)
                 copyStatus = COPY_IDLE;
+        }
+        
+        if (!pollEvent) {
+            return AKEY_NONE;
         }
     }
     


### PR DESCRIPTION
The previous fix to avoid the extra character when using the international keyboard might have add an unexpected behavior.

When the user uses the Ctrl+Shift combination, the shift key state was still set to 1 after both keys have been released.

The proposed fix moves the `return AKEY_NONE;` from the main state machine to later in the code where all the release actions have been processed. 