### PR TITLE
Fix: Preferences dialog reappears

### DIFF
--- a/atari800-MacOSX/src/Atari800MacX/Preferences.m
+++ b/atari800-MacOSX/src/Atari800MacX/Preferences.m
@@ -603,16 +603,13 @@ static NSDictionary *defaultValues() {
 
 @implementation Preferences
 
-static Preferences *sharedInstance = nil;
+static Preferences *sharedPrefsInstance = nil;
 
 + (Preferences *)sharedInstance {
-    Preferences *shared;
-    
-    if (sharedInstance)
-        return sharedInstance;
-    
-    shared = [[self alloc] init];
-    return sharedInstance ? sharedInstance : [[self alloc] init];
+    if (sharedPrefsInstance == nil)
+        sharedPrefsInstance = [[self alloc] init];
+
+    return sharedPrefsInstance;
 }
 
 /* The next few factory methods are conveniences, working on the shared instance
@@ -707,27 +704,22 @@ static Preferences *sharedInstance = nil;
 *  Constructor
 *-----------------------------------------------------------------------------*/
 - (id)init {
-    if (sharedInstance) {
-	[self dealloc];
-    } else {
-        [super init];
-        curValues = [[[self class] preferencesFromDefaults] copyWithZone:[self zone]];
-        origValues = [curValues retain];
-        [self transferValuesToEmulator];
-        [self transferValuesToAtari825];
-        [self transferValuesToAtari1020];
-        [self transferValuesToAtascii];
-        [self transferValuesToEpson];
-        commitPrefs();
-        [self discardDisplayedValues];
-        sharedInstance = self;
-		modems = [NSMutableArray array];
-		[modems retain];
-        [[PasteManager sharedInstance] setEscapeCopy:[[curValues objectForKey:EscapeCopy] boolValue]];
-        [[PasteManager sharedInstance] setStartupPasteEnabled:[[curValues objectForKey:StartupPasteEnable] boolValue]];
-        [[PasteManager sharedInstance] setStartupPasteString:[curValues objectForKey:StartupPasteString]];
-    }
-    return sharedInstance;
+    [super init];
+    curValues = [[[self class] preferencesFromDefaults] copyWithZone:[self zone]];
+    origValues = [curValues retain];
+    [self transferValuesToEmulator];
+    [self transferValuesToAtari825];
+    [self transferValuesToAtari1020];
+    [self transferValuesToAtascii];
+    [self transferValuesToEpson];
+    commitPrefs();
+    [self discardDisplayedValues];
+    modems = [NSMutableArray array];
+    [modems retain];
+    [[PasteManager sharedInstance] setEscapeCopy:[[curValues objectForKey:EscapeCopy] boolValue]];
+    [[PasteManager sharedInstance] setStartupPasteEnabled:[[curValues objectForKey:StartupPasteEnable] boolValue]];
+    [[PasteManager sharedInstance] setStartupPasteString:[curValues objectForKey:StartupPasteString]];
+    return self;
 }
 
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
Fix an issue where closing the Settings / Preferences window causes the window to re-appear.

- Apply the Singleton pattern correctly to alloc + init Preferences just once and re-use forever.
